### PR TITLE
Bumped nokogiri to secure version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,12 +68,12 @@ GEM
     lita-youtube-me (0.0.6)
       iso8601 (>= 0.8.6)
       lita (>= 4.0)
-    mini_portile (0.6.2)
+    mini_portile2 (2.3.0)
     minitest (5.10.1)
     multi_json (1.12.1)
     multipart-post (2.0.0)
-    nokogiri (1.6.6.4)
-      mini_portile (~> 0.6.0)
+    nokogiri (1.8.4)
+      mini_portile2 (~> 2.3.0)
     puma (3.8.2)
     rack (1.6.5)
     rb-readline (0.5.4)
@@ -110,4 +110,4 @@ DEPENDENCIES
   lita-youtube-me
 
 BUNDLED WITH
-   1.14.5
+   1.16.1


### PR DESCRIPTION
Ouin ben... c'est important de garder nokogiri à jour parce que y'a 1000 CVE par version dessus.